### PR TITLE
Add support for hiding env types from output of env avail

### DIFF
--- a/lib/env/commands/list_types.rb
+++ b/lib/env/commands/list_types.rb
@@ -40,7 +40,6 @@ module Env
           Table.emit do |t|
             headers 'Name', 'Summary'
             Env::Type.each do |t|
-              next if t.hidden
               row Paint[t.name, :cyan], cmd.word_wrap("#{Paint[t.summary, :green]}\n > #{Paint[t.url, :blue, :bright, :underline]}\n ", line_width: TTY::Screen.width - 30)
             end
           end

--- a/lib/env/commands/list_types.rb
+++ b/lib/env/commands/list_types.rb
@@ -40,6 +40,7 @@ module Env
           Table.emit do |t|
             headers 'Name', 'Summary'
             Env::Type.each do |t|
+              next if t.hidden
               row Paint[t.name, :cyan], cmd.word_wrap("#{Paint[t.summary, :green]}\n > #{Paint[t.url, :blue, :bright, :underline]}\n ", line_width: TTY::Screen.width - 30)
             end
           end

--- a/lib/env/type.rb
+++ b/lib/env/type.rb
@@ -70,7 +70,7 @@ module Env
                 begin
                   md = YAML.load_file(File.join(d,'metadata.yml'))
                   t = Type.new(md, d)
-                  a[t.name.to_sym] = t if t.supports_host_arch?
+                  a[t.name.to_sym] = t if t.supports_host_arch? && !t.disabled
                 rescue
                   nil
                 end
@@ -88,7 +88,7 @@ module Env
     attr_reader :url
     attr_reader :author
     attr_reader :arch
-    attr_reader :hidden
+    attr_reader :disabled
 
     def initialize(md, dir)
       @name = md[:name]
@@ -96,7 +96,7 @@ module Env
       @url = md[:url]
       @dir = dir
       @arch = md[:arch] || []
-      @hidden = md[:hidden] || false
+      @disabled = md[:disabled] || false
     end
 
     def supports_host_arch?

--- a/lib/env/type.rb
+++ b/lib/env/type.rb
@@ -88,6 +88,7 @@ module Env
     attr_reader :url
     attr_reader :author
     attr_reader :arch
+    attr_reader :hidden
 
     def initialize(md, dir)
       @name = md[:name]
@@ -95,6 +96,7 @@ module Env
       @url = md[:url]
       @dir = dir
       @arch = md[:arch] || []
+      @hidden = md[:hidden] || false
     end
 
     def supports_host_arch?


### PR DESCRIPTION
Stops env types being displayed in the output of the `avail` command. Works in a similar way to hidden desktop types in the output of `flight desktop avail`. Doesn't display env types with an optional `hidden` field set to true in the metadata.