### PR TITLE
Properly wait for less process to end before continuing

### DIFF
--- a/lib/env/commands/describe_type.rb
+++ b/lib/env/commands/describe_type.rb
@@ -57,7 +57,7 @@ module Env
         end
         wr.puts(doc.to_roff)
         wr.close
-        Process.wait
+        Process.wait(pid)
       end
     end
   end


### PR DESCRIPTION
This PR implements a fix to `describe_type` that ensures the parent Ruby process waits for the `less` fork to finish before continuing, preventing the proper killing/cleanup of the child process.